### PR TITLE
チーム情報の入力フォームを追加

### DIFF
--- a/components/DraftBox.vue
+++ b/components/DraftBox.vue
@@ -6,7 +6,7 @@
     padding="6"
     w="1500px"
   >
-    <c-grid-item v-for="n in 12" :key="`${n}`" :bg="`green.${n * 100}`">
+    <c-grid-item v-for="n in 12" :key="`${n}`">
       <TeamBox></TeamBox>
     </c-grid-item>
   </c-grid>

--- a/components/InputPlayerForm.vue
+++ b/components/InputPlayerForm.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { useForm } from '~/composables/useForm'
+import { useInputPlayerForm } from '~/composables/useInputPlayerForm'
 
-const { updateFormValue } = useForm()
-const inputPlayerName = ref('')
-const inputPosition = ref('')
-const inputBelongs = ref('')
+const { updateFormValue } = useInputPlayerForm()
+const inputPlayerName = ref<string>('')
+const inputPosition = ref<string>('')
+const inputBelongs = ref<string>('')
 
-const onClick = () => {
+const onDecisionButtonClick = () => {
   updateFormValue(
     inputPlayerName.value,
     inputPosition.value,
@@ -44,6 +44,8 @@ const onClick = () => {
         placeholder="出身"
       />
     </c-form-control>
-    <c-button variant-color="blue" size="sm" @click="onClick"> 送信 </c-button>
+    <c-button variant-color="blue" size="sm" @click="onDecisionButtonClick">
+      決定
+    </c-button>
   </c-box>
 </template>

--- a/components/InputTeamForm.vue
+++ b/components/InputTeamForm.vue
@@ -7,7 +7,7 @@ import {
 
 const { updateFormValue } = useInputTeamForm()
 
-const inputTeamName = ref('')
+const inputTeamName = ref<string>('')
 const inputIcon = ref<iconType>(initialIcon)
 const isOpen = ref<boolean>(false)
 
@@ -22,12 +22,12 @@ const findIconById = (id: number) => {
   const image = iconsDataList.find((image) => image.id == id)
   return image ?? { id: -1, ...initialIcon }
 }
-const onSelectImage = (id: number) => {
+const onIconClick = (id: number) => {
   inputIcon.value = findIconById(id)
   modalClose()
 }
 
-const onSubmitClick = () => {
+const onDecisionButtonClick = () => {
   updateFormValue(inputTeamName.value, inputIcon.value)
 }
 
@@ -86,7 +86,7 @@ const iconsDataList = [...Array(12)].map((_, i) => {
                 gap="2"
               >
                 <c-grid-item v-for="n in 12" :key="`${n}`">
-                  <div @click="onSelectImage(n)">
+                  <div @click="onIconClick(n)">
                     <c-image
                       h="40px"
                       w="60px"
@@ -103,7 +103,7 @@ const iconsDataList = [...Array(12)].map((_, i) => {
       </c-box>
     </c-form-control>
 
-    <c-button variant-color="blue" size="sm" @click="onSubmitClick">
+    <c-button variant-color="blue" size="sm" @click="onDecisionButtonClick">
       決定
     </c-button>
   </c-box>

--- a/components/InputTeamForm.vue
+++ b/components/InputTeamForm.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import {
+  useInputTeamForm,
+  iconType,
+  initialIcon,
+} from '~/composables/useInputTeamForm'
+
+const { updateFormValue } = useInputTeamForm()
+
+const inputTeamName = ref('')
+const inputIcon = ref<iconType>(initialIcon)
+const isOpen = ref<boolean>(false)
+
+const modalOpen = () => {
+  isOpen.value = true
+}
+const modalClose = () => {
+  isOpen.value = false
+}
+
+const findIconById = (id: number) => {
+  const image = iconsDataList.find((image) => image.id == id)
+  return image ?? { id: -1, ...initialIcon }
+}
+const onSelectImage = (id: number) => {
+  inputIcon.value = findIconById(id)
+  modalClose()
+}
+
+const onSubmitClick = () => {
+  updateFormValue(inputTeamName.value, inputIcon.value)
+}
+
+const altList = [
+  '読売',
+  '中日',
+  '阪神',
+  '広島',
+  'DeNA',
+  'ヤクルト',
+  'オリックス',
+  '西武',
+  'ロッテ',
+  '日本ハム',
+  'ソフトバンク',
+  '楽天',
+]
+
+const iconsDataList = [...Array(12)].map((_, i) => {
+  return { id: i + 1, src: `/flags/flag${i + 1}.gif`, alt: altList[i] }
+})
+</script>
+
+<template>
+  <c-box p="4" w="300px">
+    <c-form-control is-required mb="2">
+      <c-form-label>チーム名</c-form-label>
+      <c-input
+        v-model="inputTeamName"
+        type="text"
+        size="md"
+        placeholder="チーム名"
+      />
+    </c-form-control>
+    <c-form-control is-required mb="2">
+      <c-form-label>アイコン</c-form-label>
+      <c-box d="flex">
+        <c-button variant-color="gray" @click="modalOpen"
+          >一覧から選択</c-button
+        >
+        <c-image
+          v-if="inputIcon.src"
+          h="40px"
+          w="60px"
+          :src="inputIcon.src"
+          :alt="inputIcon.alt"
+        />
+        <c-modal :is-open="isOpen">
+          <c-modal-content ref="content">
+            <c-modal-header>アイコンを選択</c-modal-header>
+            <c-modal-close-button @click="modalClose" />
+            <c-modal-body>
+              <c-grid
+                template-rows="repeat(2, 1fr)"
+                template-columns="repeat(6, 1fr)"
+                gap="2"
+              >
+                <c-grid-item v-for="n in 12" :key="`${n}`">
+                  <div @click="onSelectImage(n)">
+                    <c-image
+                      h="40px"
+                      w="60px"
+                      :src="findIconById(n).src"
+                      :alt="findIconById(n).alt"
+                    />
+                  </div>
+                </c-grid-item>
+              </c-grid>
+            </c-modal-body>
+          </c-modal-content>
+          <c-modal-overlay />
+        </c-modal>
+      </c-box>
+    </c-form-control>
+
+    <c-button variant-color="blue" size="sm" @click="onSubmitClick">
+      決定
+    </c-button>
+  </c-box>
+</template>

--- a/components/TeamBox.vue
+++ b/components/TeamBox.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
 import { useForm } from '~/composables/useForm'
+import { useInputTeamForm } from '~/composables/useInputTeamForm'
 
 const { playerName, position, belongs } = useForm()
-
-const teamName = '巨人'
-const imageUrl = '/flags/flag1.gif'
-const imageAlt = 'Rear view of modern home with pool'
+const { teamName, icon } = useInputTeamForm()
 </script>
 
 <template>
   <c-box w="225px" h="140px" border-width="1px" rounded="lg" overflow="hidden">
     <c-box d="flex" align-items="center">
-      <c-image h="30px" :src="imageUrl" :alt="imageAlt" />
+      <c-image
+        v-if="icon.src"
+        h="30px"
+        w="45px"
+        :src="icon.src"
+        :alt="icon.alt"
+      />
       <c-box
         color="black.500"
         font-weight="semibold"

--- a/components/TeamBox.vue
+++ b/components/TeamBox.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { useForm } from '~/composables/useForm'
+import { useInputPlayerForm } from '~/composables/useInputPlayerForm'
 import { useInputTeamForm } from '~/composables/useInputTeamForm'
 
-const { playerName, position, belongs } = useForm()
+const { playerName, position, belongs } = useInputPlayerForm()
 const { teamName, icon } = useInputTeamForm()
 </script>
 

--- a/composables/useInputPlayerForm.ts
+++ b/composables/useInputPlayerForm.ts
@@ -1,7 +1,7 @@
-export const useForm = () => {
-  const playerName = useState('playerName', () => '')
-  const position = useState('position', () => '')
-  const belongs = useState('belongs', () => '')
+export const useInputPlayerForm = () => {
+  const playerName = useState<string>('playerName', () => '')
+  const position = useState<string>('position', () => '')
+  const belongs = useState<string>('belongs', () => '')
 
   const updateFormValue =
     (playerName: Ref<string>, position: Ref<string>, belongs: Ref<string>) =>

--- a/composables/useInputTeamForm.ts
+++ b/composables/useInputTeamForm.ts
@@ -1,0 +1,24 @@
+export type iconType = {
+  src: string
+  alt: string
+}
+export const initialIcon: iconType = { src: '', alt: '' }
+
+export const useInputTeamForm = () => {
+  const teamName = useState<string>('teamName', () => '')
+
+  const icon = useState<iconType>('icon', () => initialIcon)
+
+  const updateFormValue =
+    (teamName: Ref<string>, icon: Ref<iconType>) =>
+    (inputTeamName: string, inputIcon: iconType) => {
+      teamName.value = inputTeamName
+      icon.value = inputIcon
+    }
+
+  return {
+    teamName: readonly(teamName),
+    icon: readonly(icon),
+    updateFormValue: updateFormValue(teamName, icon),
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,8 @@
       justify-content="center"
     >
       <DraftBox />
-      <InputForm />
+      <InputPlayerForm />
+      <InputTeamForm />
     </CBox>
   </div>
 </template>


### PR DESCRIPTION
## 概要
チーム情報の入力フォームを追加

## やったこと
- チーム情報の入力フォーム(`InputTeamForm.vue`)と、それ用のStateを作成
- stateやrefに可能な限り型を付与

## 動作確認
- チーム名とアイコンを入力すると、中央の画面に反映されていることを確認
![image](https://user-images.githubusercontent.com/40588536/159649689-493f30b0-62d7-4bef-b715-e8c817b88f7a.png)
- モーダルの動作確認
![image](https://user-images.githubusercontent.com/40588536/159649723-9e6222b3-59a8-4740-b252-8dbac488afde.png)
